### PR TITLE
Update blank to Mesa 20.1.9

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 NOTE: The following copyright notices and license pertain only to the packaging files within this directory. Referenced source, binary and contrib files may be governed by other licenses.
 
-Copyright 2019 Auston Stewart
+Copyright 2020 Auston Stewart
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/build.sh
+++ b/build.sh
@@ -16,15 +16,19 @@ mkdir build &&
 cd build &&
 meson --prefix=/usr                    \
       --sysconfdir=/etc                \
+      -Dbuildtype=release              \
       -Ddri-drivers=                   \
       -Dvulkan-drivers=                \
       -Dgallium-drivers=${SHED_PKG_LOCAL_GALLIUM_DRIVERS} \
-      -Dlibunwind=false                \
       -Dplatforms=${SHED_PKG_LOCAL_PLATFORMS} \
       -Dgbm=true                       \
       -Degl=true                       \
       -Dllvm=false                     \
+      -Dosmesa=gallium                 \
       -Dglx=disabled                   \
+      -Dvalgrind=false                 \
+      -Dlibunwind=false                \
+      -Dgallium-nine=false             \
       ..                              &&
 NINJAJOBS=$SHED_NUM_JOBS ninja &&
 DESTDIR="$SHED_FAKE_ROOT" ninja install || exit 1

--- a/package.txt
+++ b/package.txt
@@ -1,9 +1,9 @@
 NAME=mesa
-VERSION=19.1.0
-REVISION=4
+VERSION=20.1.9
+REVISION=5
 LICENSE=MIT
-SRC=https://mesa.freedesktop.org/archive/mesa-19.1.0.tar.xz
-SRCMD5=090cd351cf938fc1729dee983520216a
+SRC=https://mesa.freedesktop.org/archive/mesa-20.1.9.tar.xz
+SRCMD5=a29ff0d65a067ffaf08e4c48fd6d2d03
 BUILDDEPS=meson ninja python_mako libdrm wayland:wayland wayland:wayland-protocols
 INSTALLDEPS=libdrm wayland:wayland wayland:wayland-protocols
 OPTIONS=(lima|panfrost) (wayland)


### PR DESCRIPTION
Various improvements to the Lima and Panfrost drivers have been made in recent Mesa. Let's pull it into Blank for further testing.